### PR TITLE
add a  maximum ban time

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,6 +7,7 @@ local db = { }
 local tempbans = { }
 
 local DEF_SAVE_INTERVAL = 300 -- 5 minutes
+local MAX_BAN_TIME = 31104000 -- 1 year  but  can be savely changed to higher or lower
 local DEF_DB_FILENAME = minetest.get_worldpath().."/xban.db"
 
 local DB_FILENAME = minetest.settings:get("xban.db_filename")
@@ -358,6 +359,7 @@ local function save_db()
 end
 
 local function load_db()
+	local now = os.time()
 	local f, e = io.open(DB_FILENAME, "rt")
 	if not f then
 		WARNING("Unable to load database: %s", e)
@@ -379,6 +381,10 @@ local function load_db()
 	for _, entry in ipairs(db) do
 		if entry.banned and entry.expires then
 			table.insert(tempbans, entry)
+		else
+			local wwe = entry
+			wwe.expires = now + MAX_BAN_TIME
+			table.insert(tempbans, )
 		end
 	end
 end

--- a/init.lua
+++ b/init.lua
@@ -384,9 +384,22 @@ local function load_db()
 		else
 			local wwe = entry
 			wwe.expires = now + MAX_BAN_TIME
-			table.insert(tempbans, )
+			table.insert(tempbans, entry)
 		end
 	end
+	local i = 1
+	while i <= #db do
+		if not db[i].banned then
+			-- not banned, remove from db
+			table.remove(db, i)
+		else
+				-- banned, hold entry back
+			i = i + 1
+			if not db[i].expires then
+				db[i].expires = now + MAX_BAN_TIME
+		end
+	end
+	
 end
 
 minetest.register_chatcommand("xban_cleanup", {


### PR DESCRIPTION
this pull request automatically upgrades perm banned players to temp banned players with a ban-time of 1 year
the ban time can be changed in the init.lua file (also it probably will not work as intented  )
anyway    the issue this solves is when a banned player moves to a new location ,   and the IP of the banned players old location is still banned   so the person that moves there cannot play on whatever server the banned player got banned on 

- [ ] adjust max ban time to balance the risk vs reward --  adjust it to balance how likely it is someone new moves to the banned IP and finds it unbanned (if he tries to go to server )    vs how likely it is the banned player will discover he / she got unbanned 

  

- [ ]  get merged

- [ ] wait 1 year and get unbanned from ctf server       ,yeah just close this pull request now xD  
