### PR TITLE
amend load print

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -416,3 +416,6 @@ minetest.after(1, check_temp_bans)
 
 dofile(xban.MP.."/dbimport.lua")
 dofile(xban.MP.."/gui.lua")
+
+-- print to log after mod was loaded successfully
+print ("[MOD] XBan2 loaded")


### PR DESCRIPTION
Add a final **print to log** at the end of `init.lua` to indicate the mod was loaded successfully. This idea was derived from other mods which are specifically aimed at MT servers.

This could be useful not only for player support (e.g. in the MT forum) but would certainly be useful for MT server admins using the CLI and reading their server logs.